### PR TITLE
Fix workflow trigger: use check_run instead of check_suite

### DIFF
--- a/.github/workflows/deploy-approved-prs.yml
+++ b/.github/workflows/deploy-approved-prs.yml
@@ -1,14 +1,14 @@
 name: Deploy Approved PRs to GitHub Pages
 
 on:
-  check_suite:
+  check_run:
     types: [completed]
   workflow_dispatch:  # Allow manual triggering
 
 jobs:
   deploy-merged-prs:
     runs-on: ubuntu-latest
-    if: github.event.check_suite.conclusion == 'success' || github.event_name == 'workflow_dispatch'
+    if: github.event.check_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
## Summary
- Fix workflow trigger to use `check_run` instead of `check_suite`
- `check_suite` events are unreliable and often not triggered
- `check_run` events fire consistently when individual checks complete

## Why this change?
As colleague noted, `check_suite` events are rarely triggered in practice. This prevents the deployment workflow from running when PRs have passing checks.

🤖 Generated with [Claude Code](https://claude.ai/code)