### PR TITLE
Fix workflow: properly set GitHub Actions output

### DIFF
--- a/.github/workflows/deploy-approved-prs.yml
+++ b/.github/workflows/deploy-approved-prs.yml
@@ -65,6 +65,9 @@ jobs:
           }
 
           console.log(`Found ${approvedPRs.length} approved PRs with passing checks:`, approvedPRs.map(pr => `#${pr.number}: ${pr.title}`));
+
+          // Set the output for GitHub Actions
+          core.setOutput('result', JSON.stringify(approvedPRs));
           return approvedPRs;
 
     - name: Merge approved PRs


### PR DESCRIPTION
## Problem
The deployment workflow was finding PRs correctly but all subsequent steps were being skipped because the output wasn't set properly.

## Solution  
- Add `core.setOutput('result', JSON.stringify(approvedPRs))` to properly set the GitHub Actions output
- This allows the `if: fromJson(steps.get-prs.outputs.result).length > 0` condition to work correctly

## Result
Subsequent steps (merge, build, deploy) will now run when PRs are found.

🤖 Generated with [Claude Code](https://claude.ai/code)